### PR TITLE
Ignore downloaded or locally built files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# By extension
+*.DS_Store
+*.log
+*.tar.gz
+*~
+
+# Specific paths and/or names
+extpkgs/
+hyperion/
+Regina-*/


### PR DESCRIPTION
Add a basic `.gitignore` to ignore files that we downloaded or built locally. This makes graphical git tools such as Visual Studio Code much less cluttered.