### PR TITLE
Update building for macOS Ventura

### DIFF
--- a/hyperion-buildall.sh
+++ b/hyperion-buildall.sh
@@ -1561,6 +1561,14 @@ detect_system()
             else
                 echo "Apple macOS version $version_str (Monterey) found"
             fi
+        elif [[ $version_major -eq 13 ]]; then
+            os_is_supported=true
+
+            if [[ "$(uname -m)" =~ ^arm64 ]]; then
+                echo "Apple macOS version $version_str (Ventura) on ARM CPU found"
+            else
+                echo "Apple macOS version $version_str (Ventura) found"
+            fi
         else
             os_is_supported=false
             echo "Apple macOS version $version_major.$version_minor found, is currently unsupported"


### PR DESCRIPTION
I know macOS Ventura is still in beta, but I wanted to run Hercules on my MacBook Air M1.

I found that the below patch was sufficient to build Hercules and see if MVS 3.8j ran on it.

This can certainly sit here until the new stable version of macOS is released.