### PR TITLE
Allow new OS/Builds via opt_prompts/--prompts

### DIFF
--- a/hercules-buildall.sh
+++ b/hercules-buildall.sh
@@ -2885,7 +2885,16 @@ https://my.velocihost.net/knowledgebase/29/Fix-the-apt-get-install-error-Media-c
 #-----------------------------------------------------------------------------
   if [ $os_is_supported != true ]; then
     error_msg "Your system ( $os_version_pretty ) is not (yet) supported!"
-    exit 1
+        if ($opt_prompts); then
+             if confirm "Continue anyway? [y/N]" ; then
+                    echo "OK"
+                else
+                    exit 1
+                fi
+            else
+                echo "Giving up"
+                exit 1
+            fi
   fi
 }
 
@@ -2948,7 +2957,16 @@ detect_bitness
 
 if [ $os_is_supported != true ]; then
     error_msg "Your system ($os_version_pretty_name) is not (yet) supported!"
-    exit 1
+    if ($opt_prompts); then
+             if confirm "Continue anyway? [y/N]" ; then
+                 echo "OK"
+             else
+                 exit 1
+             fi
+         else
+             echo "Giving up"
+             exit 1
+         fi
 fi
 
 # Detect presence of sudo and complain if it's missing


### PR DESCRIPTION
It might also be worthwhile to cp the updated $SCRIPT_DIR/patches/config.guess in more places or by default, but I'm not sure if there's a reason it's only used in specific conditions.