### PR TITLE
Pi5b 4gb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ extpkgs/
 hyperion/
 aethra/
 Regina-*/
+herc4x/

--- a/hercules-buildall.sh
+++ b/hercules-buildall.sh
@@ -525,6 +525,7 @@ function check_pi_version()
     [b03140]="CM4       1.0     2GB     Sony UK"
     [c03140]="CM4       1.0     4GB     Sony UK"
     [d03140]="CM4       1.0     8GB     Sony UK"
+    [c04170]="5B	1.0	4GB	       "
     [d04170]="5B        1.0     8GB            "
     [e04171]="5B        1.1    16GB            "
   )


### PR DESCRIPTION
This PR adds the herc4x build dir to .gitignore and c04170 to the Rev code list for Pi 5b 4GB